### PR TITLE
Update GettingStarted with note on M1 Macs

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -138,7 +138,15 @@ toolchain as a one-off, there are a couple of differences:
    The required version of Xcode changes frequently and is often a beta release.
    Check this document or the host information on <https://ci.swift.org> for the
    current required version.
-2. Install [CMake][], [Ninja][] and [Sccache][]:
+1. **If you are running on Apple Silicon hardware** (M1, M2, etc):
+   Ensure you have the native arm64 build of Python configured.
+   Run `file $(which python3)`; it should print "arm64".
+   If it prints "x86_64", you are running Python in compatibility mode (Rosetta),
+   and will need to ensure the native version of Python is installed and
+   configured in your PATH.
+   Running `uname -m` should also print "arm64", otherwise your terminal is also
+   running in Rosetta mode.
+1. Install [CMake][], [Ninja][] and [Sccache][]:
    - Via [Homebrew][] (recommended):
      ```sh
      brew install cmake ninja sccache


### PR DESCRIPTION
Running the wrong version of Python will result in the build failing a long way (>1hr) into the process, and giving an unrelated error. This note can save new contributors several hours of frustrating troubleshooting.

Contains only documentation additions.
